### PR TITLE
PHP課題（応用）FizzBuzz問題の出力結果の誤記修正

### DIFF
--- a/4_PHP課題（応用）.md
+++ b/4_PHP課題（応用）.md
@@ -150,7 +150,7 @@ Hoge
 8
 Fizz
 Buzz
-Piyo
+11
 Fizz
 13
 Hoge
@@ -161,7 +161,7 @@ Fizz
 19
 Buzz
 FizzHoge
-Piyo
+22
 23
 Fizz
 Buzz


### PR DESCRIPTION
課題21の出力結果で11の倍数で"piyo"と出力されているが、課題にはないので修正