### PR TITLE
PHP基礎課題Q5 回答例の誤りの修正（せき）

### DIFF
--- a/task_ansewr.php
+++ b/task_ansewr.php
@@ -59,12 +59,12 @@ print("#####q5#####".PHP_EOL);
 //キーワード：配列　空　判定
 
 $array1 = [];
-var_export(!empty($array1));
+var_export(empty($array1));
 
 echo PHP_EOL;
 
 $array2 = [1, 5, 8, 10];
-var_export(!empty($array2));
+var_export(empty($array2));
 
 echo PHP_EOL;
 


### PR DESCRIPTION
PHP基礎課題 Q5.にて、
空の配列があるときにtureを返す関数empty()を!で打ち消しているため
誤った回答例となっていましたので、
!を削除しました。